### PR TITLE
Add Rule name to stream_rule_notifications client

### DIFF
--- a/googleapis/rules/rule_lib.py
+++ b/googleapis/rules/rule_lib.py
@@ -137,6 +137,7 @@ class RuleLib():
           {
             'result': {'match': { ... single event in udm format ... } },
             'ruleId': 'ru_13f58277-8d41-45b2-ab6b-1addc4e3ca0e',
+            'rule': 'NameOfRule',
             'operation':
             'operations/rulejob_jo_fd826fb3-fdfa-40d0-8681-482fc014ef62'
           }, ... ]


### PR DESCRIPTION
The API now contains a new 'rule' field which contains the name of the rule that gets pushed. This PR updates the client APIs to take advantage of this new field.